### PR TITLE
Set a specific cache length

### DIFF
--- a/filehost/filehost.go
+++ b/filehost/filehost.go
@@ -284,6 +284,7 @@ func serveFile(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Content-Type", mimeType)
+	w.Header().Set("Cache-Control", "max-age=604800, public") // 7 days
 
 	http.ServeContent(w, r, "", time.Time{}, file)
 }


### PR DESCRIPTION
Adds a header so anyone would cache files for 7 days.

Not really sure if this is needed behind Cloudflare.